### PR TITLE
Add apiFlavour to fix document POST

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:json_annotation/json_annotation.dart';
-
+import 'package:flutter_secure_storage/flutter_secure_storage.dart'
+    as SecureStorage;
+import 'package:get_it/get_it.dart';
 part 'api.g.dart';
 
 @JsonSerializable()
@@ -264,12 +266,15 @@ class API {
       // Try again, with paperless-ng
       if (response.statusCode == 302) {
         this.apiFlavour = "paperless-ng";
-        // Update secure storage here?
+        await GetIt.I<SecureStorage.FlutterSecureStorage>()
+            .write(key: "api_flavour", value: "paperless-ng");
         return this.uploadFile(path);
       }
       // Try again, with paperless (this case is unlikely)
       if (response.statusCode == 405) {
         this.apiFlavour = "paperless";
+        await GetIt.I<SecureStorage.FlutterSecureStorage>()
+            .write(key: "api_flavour", value: "paperless");
         return this.uploadFile(path);
       }
     } catch (e) {

--- a/lib/routes/home_route.dart
+++ b/lib/routes/home_route.dart
@@ -18,15 +18,14 @@ class _HomeRouteState extends State<HomeRoute> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body:  Center(
-      child:
-        SizedBox(
-          height: 155.0,
-          child: SvgPicture.asset(
-            "assets/logo.svg",
-            color: Colors.green,
-            fit: BoxFit.contain,
-          ),
+        body: Center(
+      child: SizedBox(
+        height: 155.0,
+        child: SvgPicture.asset(
+          "assets/logo.svg",
+          color: Colors.green,
+          fit: BoxFit.contain,
+        ),
       ),
     ));
   }
@@ -34,7 +33,7 @@ class _HomeRouteState extends State<HomeRoute> {
   void loadData() async {
     var url = await GetIt.I<FlutterSecureStorage>().read(key: "server_url");
     if (url == null) {
-      Navigator.pushReplacement (
+      Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (context) => ServerDetailsRoute()),
       );
@@ -43,18 +42,23 @@ class _HomeRouteState extends State<HomeRoute> {
 
     var username = await GetIt.I<FlutterSecureStorage>().read(key: "username");
     var password = await GetIt.I<FlutterSecureStorage>().read(key: "password");
+    var apiFlavour =
+        await GetIt.I<FlutterSecureStorage>().read(key: "api_flavour");
 
     if (username == null || password == null) {
-      Navigator.pushReplacement (
+      Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (context) => LoginRoute()),
       );
       return;
     }
+    if (apiFlavour == null) {
+      apiFlavour = "paperless";
+    }
 
-    API(url, username: username, password: password);
+    API(url, username: username, password: password, apiFlavour: apiFlavour);
 
-    Navigator.pushReplacement (
+    Navigator.pushReplacement(
       context,
       MaterialPageRoute(builder: (context) => DocumentsRoute()),
     );

--- a/lib/routes/login_route.dart
+++ b/lib/routes/login_route.dart
@@ -41,6 +41,8 @@ class _LoginRouteState extends State<LoginRoute> {
       try {
         if (await API(serverUrl, username: username, password: password)
             .checkCredentials()) {
+          await GetIt.I<FlutterSecureStorage>()
+              .write(key: "api_flavour", value: API.instance.apiFlavour);
           Navigator.pushReplacement(
             context,
             MaterialPageRoute(builder: (context) => DocumentsRoute()),


### PR DESCRIPTION
Hello again! This implements the apiFlavour you suggested. 

- I used the availability of the `/api/token/` route when checking credentials to determine ng or not. 
- Flavour is saved in SecureStorage
- If the saved api is incorrect when posting a new document, it'll switch to the alternate route.

Let me know what you think, and if any changes should be made.