### PR TITLE
Build and add APKs to github release

### DIFF
--- a/.github/workflows/flutter_build.yml
+++ b/.github/workflows/flutter_build.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Allows this workflow to be called from other workflows
+  workflow_call:
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/flutter_build.yml
+++ b/.github/workflows/flutter_build.yml
@@ -15,6 +15,11 @@ on:
 
   # Allows this workflow to be called from other workflows
   workflow_call:
+    inputs:
+      artifactName:
+        description: "Name of the uploaded artifact"
+        required: true
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -28,6 +33,7 @@ jobs:
       KEY_PATH: /home/runner/key.jks
       KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
       KEY_ALIAS: key
+      ARTIFACT_NAME: ${{ inputs.artifactName || 'release-apk' }}
 
     steps:
     - uses: actions/checkout@v2
@@ -47,6 +53,6 @@ jobs:
     - name: Archive artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: release-apk
+        name: ${{ env.ARTIFACT_NAME }}
         path: |
           build/app/outputs/apk/*

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,0 +1,30 @@
+name: Github Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  ARTIFACT_NAME: release
+
+jobs:
+  build:
+    uses: ./.github/workflows/flutter_build.yml
+    secrets: inherit
+    with:
+      artifactName: ${{ env.ARTIFACT_NAME }}
+
+  add-artifacts-to-release:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+
+    - name: Add artifacts to release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: 'release/*.apk'

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -4,15 +4,12 @@ on:
   release:
     types: [published]
 
-env:
-  ARTIFACT_NAME: release
-
 jobs:
   build:
     uses: ./.github/workflows/flutter_build.yml
     secrets: inherit
     with:
-      artifactName: ${{ env.ARTIFACT_NAME }}
+      artifactName: 'release'
 
   add-artifacts-to-release:
     runs-on: ubuntu-latest
@@ -22,7 +19,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v3
       with:
-        name: ${{ env.ARTIFACT_NAME }}
+        name: 'release'
 
     - name: Add artifacts to release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This ticks another box for #66.

When creating a new release, the release workflow runs the build and adds the produced artifacts to the created release.
I had to change the build workflow a bit to be usable from the release workflow.